### PR TITLE
Task: adds the qunitnode multi-task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ logs
 results
 
 npm-debug.log
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "sub": true,
+  "undef": true,
+  "boss": true,
+  "eqnull": true,
+  "node": true,
+
+  "predef": {
+    "QUnit": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.10"
+before_script:
+  - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,78 @@
+"use strict";
+
+module.exports = function( grunt ) {
+
+	// Project configuration.
+	grunt.initConfig({
+		jshint: {
+			all: [
+				"Gruntfile.js",
+				"tasks/*.js",
+				"test/**/*.js",
+			],
+			options: {
+				jshintrc: ".jshintrc",
+			},
+		},
+		qunitnode: {
+			src: "test/tests.js",
+			multiple: [ "test/tests.js", "test/tests-{3,2}.js" ],
+			all: {
+				options: {
+					force: true
+				},
+				src: "test/**/*.js"
+			}
+		}
+	});
+
+	grunt.loadNpmTasks( "grunt-contrib-jshint" );
+	grunt.loadTasks( "tasks" );
+
+	// Build a mapping of url success counters.
+	var successes = {};
+	var currentUrl;
+	grunt.event.on( "qunitnode.spawn", function( url ) {
+		currentUrl = url;
+		if ( !successes[ currentUrl ] ) {
+			successes[ currentUrl ] = 0;
+		}
+	});
+	grunt.event.on( "qunitnode.done", function( failed, passed ) {
+		var urls = {
+				"test/tests.js": [ 3, 0 ],
+				"test/tests-2.js": [ 3, 0 ],
+				"test/tests-3.js": [ 3, 0 ],
+				"test/tests-fail.js": [ 0, 3 ],
+			},
+			currUrlPassed = urls[ currentUrl ][ 0 ],
+			currUrlFailed = urls[ currentUrl ][ 1 ];
+
+		if ( failed === currUrlFailed && passed === currUrlPassed ) {
+			successes[ currentUrl ]++;
+		}
+	});
+
+	grunt.registerTask( "really-test", "Test to see if qunit task actually worked.", function() {
+		var assert = require( "assert" );
+		var difflet = require( "difflet" )( { indent: 2, comment: true } );
+		var actual = successes;
+		var expected = {
+			"test/tests.js": 3,
+			"test/tests-2.js": 2,
+			"test/tests-3.js": 2,
+			"test/tests-fail.js": 1
+		};
+
+		try {
+			assert.deepEqual( actual, expected, "Actual should match expected." );
+		} catch ( err ) {
+			grunt.log.subhead( "Actual should match expected." );
+			console.log( difflet.compare( expected, actual ) );
+			throw new Error( err.message );
+		}
+	});
+
+	grunt.registerTask( "test", [ "default" ] );
+	grunt.registerTask( "default", [ "jshint", "qunitnode", "really-test" ] );
+};

--- a/LICENSE-MIT.txt
+++ b/LICENSE-MIT.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2014 James M. Greene, http://jamesgreene.net/
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+and logs, available at https://github.com/jquery/qunitjs.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-grunt-node-qunit
+grunt-qunitnode
 ================
 
 A Grunt task plugin to execute QUnit tests in Node.js.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "grunt-qunitnode",
+  "version": "0.0.1",
+  "description": "A Grunt task plugin to execute QUnit tests in Node.js.",
+  "main": "tasks/qunitnode.js",
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/JamesMGreene/grunt-qunitnode.git"
+  },
+  "author": "James M. Greene",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/JamesMGreene/grunt-qunitnode/issues"
+  },
+  "homepage": "https://github.com/JamesMGreene/grunt-qunitnode",
+  "peerDependencies": {
+    "qunitjs": "1.x"
+  },
+  "devDependencies": {
+    "chalk": "0.4.0",
+    "difflet": "0.2.6",
+    "grunt": "0.4.2",
+    "grunt-contrib-jshint": "0.8.0",
+    "qunitjs": "~1.14.0"
+  },
+  "keywords": [
+    "QUnit",
+    "Grunt",
+    "Node",
+    "gruntplugin"
+  ]
+}

--- a/tasks/qunitnode.js
+++ b/tasks/qunitnode.js
@@ -1,0 +1,176 @@
+/*
+ * grunt-qunitnode
+ * https://github.com/JamesMGreene/grunt-qunitnode
+ *
+ * Copyright (c) 2012 JamesMGreene
+ * Licensed under the MIT license.
+ */
+
+"use strict";
+
+module.exports = function( grunt ) {
+	var QUnit = require( "qunitjs" ),
+		path = require( "path" ),
+		chalk = require( "chalk" ),
+
+		// Keep track of the last-started test and status.
+		next, options, currentTest, status,
+
+		// Keep track of the last-started test(s).
+		unfinished = {},
+
+		// Keep track of failed assertions for pretty-printing.
+		failedAssertions = [];
+
+	// Allow an error message to retain its color when split across multiple lines.
+	function formatMessage( str ) {
+		return String( str ).split( "\n" ).map(function( s ) {
+			return chalk.magenta( s );
+		}).join( "\n" );
+	}
+
+	// If options.force then log an error, otherwise exit with a warning
+	function warnUnlessForced( message ) {
+		if ( options.force ) {
+			grunt.log.error( message );
+		} else {
+			grunt.warn( message );
+		}
+	}
+
+	function moduleAndName( details ) {
+		var mod = details.module;
+
+		mod = mod ? mod + " - " : "";
+
+		return chalk.cyan( mod + details.name );
+	}
+
+	function logFailedAssertions() {
+		var assertion;
+
+		// Print each assertion error.
+		while ( assertion = failedAssertions.shift() ) {
+			grunt.verbose.or.error( moduleAndName( assertion ) );
+			warnUnlessForced( "Message: " + formatMessage( assertion.message ) );
+
+			if ( assertion.actual !== assertion.expected ) {
+				warnUnlessForced( "Actual: " + formatMessage( assertion.actual ) );
+				warnUnlessForced( "Expected: " + formatMessage( assertion.expected ) );
+			}
+
+			if ( assertion.source ) {
+				warnUnlessForced( assertion.source.replace( / {4}(at)/g, " $1" ) );
+			}
+
+			grunt.log.writeln();
+		}
+	}
+
+	QUnit.log(function( details ) {
+		if ( ! details.result ) {
+			failedAssertions.push( details );
+		}
+	});
+
+	QUnit.testStart(function( details ) {
+		var currentTest = moduleAndName( details );
+
+		grunt.verbose.write( chalk.cyan( currentTest + "... " ) );
+	});
+
+	QUnit.testDone(function( details ) {
+		var name = details.name, 
+			failed = details.failed;
+
+		// Log errors if necessary, otherwise success.
+		if ( failed > 0 ) {
+
+			// list assertions
+			if ( grunt.option( "verbose" ) ) {
+				grunt.log.error();
+				logFailedAssertions();
+			} else {
+				grunt.log.write( chalk.red( "F" ) );
+			}
+		} else {
+			grunt.verbose.ok().or.write( chalk.green( "." ) );
+		}
+	});
+
+	QUnit.done(function( details ) {
+		var failed = details.failed,
+			passed = details.passed,
+			total = details.total,
+			runtime = details.runtime;
+
+		status.failed += failed;
+		status.passed += passed;
+		status.total += total;
+		status.runtime += runtime;
+
+		// Print assertion errors here, if verbose mode is disabled.
+		if ( !grunt.option( "verbose" ) ) {
+			if ( failed > 0 ) {
+				grunt.log.writeln();
+				logFailedAssertions();
+			} else if ( total === 0 ) {
+				warnUnlessForced( "0/0 assertions ran (" + runtime + "ms)" );
+			} else {
+				grunt.log.ok();
+			}
+		}
+
+		grunt.event.emit( "qunitnode.done", failed, passed );
+		next();
+	});
+
+	grunt.registerMultiTask( "qunitnode", "QUnit tests in Node.js.", function() {		
+		var done = this.async();
+
+		// Merge task-specific and/or target-specific options with these defaults.
+		options = this.options({
+			force: false
+		});
+
+		// Reset status.
+		status = { failed: 0, passed: 0, total: 0, runtime: 0 };
+
+		grunt.util.async.forEachSeries( this.filesSrc, function( src, nextStep ) {
+			var testFile = path.join( __dirname, "../" + src );
+
+			grunt.event.emit( "qunitnode.spawn", src );
+
+			QUnit.config.autostart = false;
+			QUnit.init();
+
+			grunt.verbose.subhead( "Testing " + src + " ").or.write( "Testing " + src + " " );
+
+			// forces test file reload if already required once
+			// Example: multiple grunt subtasks
+			delete require.cache[ require.resolve( testFile ) ];
+			require( testFile );
+
+			QUnit.load();
+
+			next = nextStep;
+		},
+
+		// All tests have been run.
+		function() {
+			if ( status.failed > 0 ) {
+				warnUnlessForced( status.failed + "/" + status.total +
+					" assertions failed (" + status.runtime + "ms)" );
+			} else if ( status.total === 0 ) {
+				warnUnlessForced( "0/0 assertions ran (" + status.runtime + "ms)" );
+			} else {
+				grunt.verbose.writeln();
+				grunt.log.ok(status.total + " assertions passed (" + status.runtime + "ms)" );
+			}
+
+			// All done!
+			done();
+		});
+
+	});
+};

--- a/test/tests-2.js
+++ b/test/tests-2.js
@@ -1,0 +1,10 @@
+QUnit.module( "passing module 2" );
+
+QUnit.test( "foo 2", function( assert ) {
+	assert.ok( true, "pass!" );
+	assert.strictEqual( true, true );
+});
+
+QUnit.test( "bar 2", function( assert ) {
+	assert.deepEqual( [ 1, 2, 3 ], [ 1, 2, 3 ] );
+});

--- a/test/tests-3.js
+++ b/test/tests-3.js
@@ -1,0 +1,10 @@
+QUnit.module( "passing module 3" );
+
+QUnit.test( "foo 3", function( assert ) {
+	assert.ok( true, "pass!" );
+	assert.strictEqual( true, true );
+});
+
+QUnit.test( "bar 3", function( assert ) {
+	assert.deepEqual( [ 1, 2, 3 ], [ 1, 2, 3 ] );
+});

--- a/test/tests-fail.js
+++ b/test/tests-fail.js
@@ -1,0 +1,10 @@
+QUnit.module( "not passing module" );
+
+QUnit.test( "foo", function( assert ) {
+	assert.ok( 0, "you shall not pass!" );
+	assert.strictEqual( true, false );
+});
+
+QUnit.test( "bar", function( assert ) {
+	assert.deepEqual( [ 1, 2, 3 ], [] );
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,0 +1,10 @@
+QUnit.module( "passing module" );
+
+QUnit.test( "foo", function( assert ) {
+	assert.ok( true, "pass!" );
+	assert.strictEqual( true, true );
+});
+
+QUnit.test( "bar", function( assert ) {
+	assert.deepEqual( [ 1, 2, 3 ], [ 1, 2, 3 ] );
+});


### PR DESCRIPTION
it's really hard to choose the best name for anything. I've pushed the task as `qunitn` but I can rename it.

Suggestions:
- `qunitnode`
- `node-qunit`
- `nodeQUnit`
- `qunit` (actually I don't want this one because I want to plug this task in another project that should run tests with PhantomJS and Node environments. That might conflict, right?

Edit: the tests and methods were written after `grunt-contrib-qunit`. 
